### PR TITLE
fix(htmlhint) activted task + fixed errors hinted in html files

### DIFF
--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -18,6 +18,7 @@ import path from '../paths';
  */
 gulp.task('htmlhint', () => {
     return gulp.src([path.app.html, path.app.templates])
+        .pipe(htmlhint('.htmlhintrc'))
         .pipe(htmlhint.reporter())
         .pipe(htmlhint.failReporter());
 });

--- a/src/app/routes/layout-app/documents-files/documents-files.html
+++ b/src/app/routes/layout-app/documents-files/documents-files.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
     <div class="panel panel-inverse">
         <div class="panel-heading">
-            <h4 class="panel-title"><a ui-sref="app.documents">Documents</a> > {{::vm.folderName.name}}</h4>
+            <h4 class="panel-title"><a ui-sref="app.documents">Documents</a> &gt; {{::vm.folderName.name}}</h4>
         </div>
         <div class="panel-body">
             <div ng-if="vm.hasError" class="row">
@@ -15,7 +15,7 @@
             <div class="row">
                 <div class="col-md-6 col-sm-6">
                     <div class="table-filter">
-                        Search: <input type="search" ng-model="vm.searchText"></span>
+                        Search: <input type="search" ng-model="vm.searchText">
                     </div>
                 </div>
                 <div class="col-md-6 col-sm-6">

--- a/src/app/routes/layout-app/documents/documents.html
+++ b/src/app/routes/layout-app/documents/documents.html
@@ -15,7 +15,7 @@
             <div class="row">
                 <div class="col-md-6 col-sm-6">
                     <div class="table-filter">
-                        Search: <input type="search" ng-model="vm.searchText"></span>
+                        Search: <input type="search" ng-model="vm.searchText">
                     </div>
                 </div>
                 <div class="col-md-6 col-sm-6">


### PR DESCRIPTION
The `gulp htmlhint` task wasn't hinting any html (init call missing).
Now, it does its job (the rules in the `.htmlhintrc` file are taken in account).
I had to fix 3 errors in the html templates to be able to commit (it cleaned up the html).