### PR TITLE
fix(gulp/tasks) minified files appearing multiple times in gulp-size

### DIFF
--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -96,7 +96,6 @@ gulp.task('extras', () => {
  * @return {Stream}
  */
 gulp.task('compile', ['htmlhint', 'sass', 'bundle'], () => {
-    const projectHeader = header(BANNER);
 
     return gulp.src(path.app.html)
         .pipe(inject(gulp.src(path.tmp.scripts + 'build.js', {read: false}), {
@@ -114,7 +113,7 @@ gulp.task('compile', ['htmlhint', 'sass', 'bundle'], () => {
                 minifyCss({keepSpecialComments: 0}),
                 bytediff.stop(bytediffFormatter),
                 rev(),
-                projectHeader
+                header(BANNER)
             ],
             /*jshint camelcase: false */
             js:         [
@@ -123,7 +122,7 @@ gulp.task('compile', ['htmlhint', 'sass', 'bundle'], () => {
                 uglify(),
                 bytediff.stop(bytediffFormatter),
                 rev(),
-                projectHeader
+                header(BANNER)
             ],
             html:       [
                 gulpif(HAS_CDN, cdnizer({defaultCDNBase: CDN_URL, files: ['**/*.{js,css,gif,png,jpg,jpeg}']})),


### PR DESCRIPTION
before:

`gulp build`

```
...
[19:12:09] 'compile' scripts/main.min-60aa5c2e2a.js 706.61 kB
[19:12:09] 'compile' scripts/main.min-60aa5c2e2a.js 706.61 kB
[19:12:09] 'compile' styles/main.min-e978850959.css 214.12 kB
[19:12:09] 'compile' styles/main.min-e978850959.css 214.12 kB
[19:12:09] 'compile' index.html 390 B
[19:12:09] 'compile' all files 1.84 MB
...
```

You can see that the `gulp-size` appears twice for the minified files, which gives an incorrect total.
This must be an edge case between `gulp-header`, `gulp-usemin` and `gulp-size`.
I couldn't find out the exact source of the bug.

The simple fix is not to store `header(BANNER)` inside `projectHeader`, but use it right away

after:

`gulp build`

```
...
[19:28:21] 'compile' scripts/main.min-60aa5c2e2a.js 706.61 kB
[19:28:21] 'compile' styles/main.min-e978850959.css 214.12 kB
[19:28:21] 'compile' index.html 390 B
[19:28:21] 'compile' all files 921.12 kB
...
```

This way, you have the correct "all files" weight.